### PR TITLE
Bug fixes and refactor to use singletons

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,7 @@
     },
     "autoload": {
         "files": [
-            "includes/facades.php",
-            "includes/helpers.php"
+            "includes/scope.php"
         ],
         "psr-4": {
             "ProcessMaker\\": "src/ProcessMaker/"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=7.4",
+        "php": ">=7.2",
         "ext-json": "*",
         "ext-posix": "*",
         "illuminate/support": "^8.73",
@@ -35,7 +35,7 @@
             "includes/helpers.php"
         ],
         "psr-4": {
-            "ProcessMaker\\Cli\\": "cli/ProcessMaker/"
+            "ProcessMaker\\": "src/ProcessMaker/"
         }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bbb246ebeb21165b32498afdd0a2fe7f",
+    "content-hash": "6f35bd6bb3e060d71c11d90d5bc02d53",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -7839,7 +7839,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.4",
+        "php": ">=7.2",
         "ext-json": "*",
         "ext-posix": "*"
     },

--- a/includes/facades.php
+++ b/includes/facades.php
@@ -19,7 +19,9 @@ abstract class Facade
      */
     public static function __callStatic(string $method, array $parameters)
     {
-        $resolvedInstance = Container::getInstance()->make(static::containerKey());
+        Container::getInstance()->singletonIf($key = static::containerKey());
+
+        $resolvedInstance = Container::getInstance()->make($key);
 
         return call_user_func_array([$resolvedInstance, $method], $parameters);
     }
@@ -29,71 +31,71 @@ abstract class Facade
      */
     public static function containerKey(): string
     {
-        return 'ProcessMaker\\Cli\\'.basename(str_replace('\\', '/', static::class));
+        return 'ProcessMaker\\'.basename(str_replace('\\', '/', static::class));
     }
 }
 
 /**
- * @see \ProcessMaker\Cli\CommandLine
+ * @see \ProcessMaker\CommandLine
  */
 class CommandLine extends Facade {}
 
 /**
- * @see \ProcessMaker\Cli\FileSystem
+ * @see \ProcessMaker\FileSystem
  */
 class FileSystem extends Facade {}
 
 /**
- * @see \ProcessMaker\Cli\Packages
+ * @see \ProcessMaker\Packages
  */
 class Packages extends Facade {}
 
 /**
- * @see \ProcessMaker\Cli\Install
+ * @see \ProcessMaker\Install
  */
 class Install extends Facade {}
 
 /**
- * @see \ProcessMaker\Cli\ProcessManager
+ * @see \ProcessMaker\ProcessManager
  */
 class ProcessManager extends Facade {}
 
 /**
- * @see \ProcessMaker\Cli\Composer
+ * @see \ProcessMaker\Composer
  */
 class Composer extends Facade {}
 
 /**
- * @see \ProcessMaker\Cli\Git
+ * @see \ProcessMaker\Git
  */
 class Git extends Facade {}
 
 /**
- * @see \ProcessMaker\Cli\PackagesCi
+ * @see \ProcessMaker\PackagesCi
  */
 class PackagesCi extends Facade {}
 
 /**
- * @see \ProcessMaker\Cli\Config
+ * @see \ProcessMaker\Config
  */
 class Config extends Facade {}
 
 /**
- * @see \ProcessMaker\Cli\Supervisor
+ * @see \ProcessMaker\Supervisor
  */
 class Supervisor extends Facade {}
 
 /**
- * @see \ProcessMaker\Cli\Reset
+ * @see \ProcessMaker\Reset
  */
 class Reset extends Facade {}
 
 /**
- * @see \ProcessMaker\Cli\Reset
+ * @see \ProcessMaker\Reset
  */
 class IDE extends Facade {}
 
 /**
- * @see \ProcessMaker\Cli\Reset
+ * @see \ProcessMaker\Reset
  */
 class Environment extends Facade {}

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -2,15 +2,11 @@
 
 declare(strict_types=1);
 
-namespace ProcessMaker;
-
 use Illuminate\Container\Container;
 use ProcessMaker\Facades\CommandLine as Cli;
 use ProcessMaker\Facades\Config;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Output\ConsoleOutput;
-
-use function random_int;
 
 if (!defined('HOMEBREW_PREFIX')) {
     define('HOMEBREW_PREFIX', Cli::run('printf $(brew --prefix)'));

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -2,24 +2,25 @@
 
 declare(strict_types=1);
 
-namespace ProcessMaker\Cli;
+namespace ProcessMaker;
 
 use Illuminate\Container\Container;
 use ProcessMaker\Facades\CommandLine as Cli;
 use ProcessMaker\Facades\Config;
-use RuntimeException;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
-if (! defined('HOMEBREW_PREFIX')) {
+use function random_int;
+
+if (!defined('HOMEBREW_PREFIX')) {
     define('HOMEBREW_PREFIX', Cli::run('printf $(brew --prefix)'));
 }
 
-if (! defined('PM_HOME_PATH')) {
+if (!defined('PM_HOME_PATH')) {
     define('PM_HOME_PATH', $_SERVER['HOME'] . '/.config/pm');
 }
 
-if (! defined('USER_HOME')) {
+if (!defined('USER_HOME')) {
     define('USER_HOME', getenv('HOME'));
 }
 
@@ -29,8 +30,7 @@ if (! defined('USER_HOME')) {
  *
  * @return string
  */
-function warningThenExit(string $output, int $exitCode = 0): string
-{
+function warningThenExit(string $output, int $exitCode = 0): string {
     return warning($output) . exit($exitCode);
 }
 
@@ -46,8 +46,8 @@ function warningThenExit(string $output, int $exitCode = 0): string
  *
  * @throws \Exception
  */
-function tmpdir($dir = null, $prefix = 'tmp_', $mode = 0700, $maxAttempts = 100)
-{
+function tmpdir($dir = null, $prefix = 'tmp_', $mode = 0700, $maxAttempts = 100) {
+
     if (is_null($dir)) {
         $dir = sys_get_temp_dir();
     }
@@ -65,7 +65,7 @@ function tmpdir($dir = null, $prefix = 'tmp_', $mode = 0700, $maxAttempts = 100)
     $attempts = 0;
 
     do {
-        $path = sprintf('%s%s%s%s', $dir, DIRECTORY_SEPARATOR, $prefix, \random_int(100000, mt_getrandmax()));
+        $path = sprintf('%s%s%s%s', $dir, DIRECTORY_SEPARATOR, $prefix, random_int(100000, mt_getrandmax()));
     } while (! mkdir($path, $mode) && $attempts++ < $maxAttempts);
 
     return $path;
@@ -76,8 +76,7 @@ function tmpdir($dir = null, $prefix = 'tmp_', $mode = 0700, $maxAttempts = 100)
  *
  * @return string
  */
-function pm_path(?string $filename = null)
-{
+function pm_path(?string $filename = null) {
     return PM_HOME_PATH . ($filename ? DIRECTORY_SEPARATOR . $filename : '');
 }
 
@@ -86,8 +85,7 @@ function pm_path(?string $filename = null)
  *
  * @return mixed
  */
-function codebase_path(?string $filename = null)
-{
+function codebase_path(?string $filename = null) {
     return Config::codebasePath($filename);
 }
 
@@ -96,8 +94,7 @@ function codebase_path(?string $filename = null)
  *
  * @return mixed
  */
-function packages_path(?string $filename = null)
-{
+function packages_path(?string $filename = null) {
     return Config::packagesPath($filename);
 }
 
@@ -108,8 +105,7 @@ function packages_path(?string $filename = null)
  *
  * @throws \Illuminate\Contracts\Container\BindingResolutionException
  */
-function resolve(string $class)
-{
+function resolve(string $class) {
     return Container::getInstance()->make($class);
 }
 
@@ -118,44 +114,28 @@ function resolve(string $class)
  *
  * @param  mixed  $instance
  */
-function swap(string $class, $instance): void
-{
+function swap(string $class, $instance): void {
     Container::getInstance()->instance($class, $instance);
 }
 
 /**
  * @return mixed
  */
-function user()
-{
+function user() {
     return $_SERVER['SUDO_USER'] ?? $_SERVER['USER'];
-}
-
-/**
- * Verify that the script is currently running as "sudo".
- *
- * @throws \Exception
- */
-function should_be_sudo(): void
-{
-    if (! isset($_SERVER['SUDO_USER'])) {
-        throw new RuntimeException('This command must be run with sudo.');
-    }
 }
 
 /**
  * Output the given text to the console.
  */
-function info(string $output): void
-{
+function info(string $output): void {
     output('<info>'.$output.'</info>');
 }
 
 /**
  * Output the given text to the console.
  */
-function warning(string $output): void
-{
+function warning(string $output): void {
     output('<fg=red>' . $output . '</>');
 }
 
@@ -165,8 +145,7 @@ function warning(string $output): void
  * @param array $headers
  * @param array $rows
  */
-function table(array $headers = [], array $rows = []): void
-{
+function table(array $headers = [], array $rows = []): void {
     $table = new Table(new ConsoleOutput());
     $table->setHeaders($headers)->setRows($rows);
     $table->render();
@@ -175,8 +154,7 @@ function table(array $headers = [], array $rows = []): void
 /**
  * Output the given text to the console.
  */
-function output(string $output): void
-{
+function output(string $output): void {
     if (isset($_ENV['APP_ENV']) && $_ENV['APP_ENV'] === 'testing') {
         return;
     }

--- a/includes/scope.php
+++ b/includes/scope.php
@@ -1,0 +1,18 @@
+<?php
+
+// We only want to require the other include files when
+// the SOURCE env variable is defined...
+if (!($source = getenv('SOURCE'))) {
+    return;
+}
+
+// and when it is indicating the ../pm
+// executable was called
+if (!str_contains($source, '/pm')) {
+    return;
+}
+
+// Otherwise we can go ahead and load the
+// other includes and continue as normal
+require_once __DIR__.'/facades.php';
+require_once __DIR__.'/helpers.php';

--- a/pm
+++ b/pm
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-SOURCE="${BASH_SOURCE[0]}"
+export SOURCE="${BASH_SOURCE[0]}"
 
 # If the current source is a symbolic link, we need to resolve it to an
 # actual directory name. We'll use PHP to do this easier than we can

--- a/pm
+++ b/pm
@@ -14,13 +14,8 @@ fi
 # If we are in the global Composer "bin" directory, we need to bump our
 # current directory up two, so that we will correctly proxy into the
 # Valet CLI script which is written in PHP. Will use PHP to do it.
-if [ ! -f "$DIR/cli/pm.php" ]; then
+if [ ! -f "$DIR/src/pm.php" ]; then
     DIR=$(php -r "echo realpath('$DIR/../runyan-co/pm');")
 fi
 
-#if [[ "$EUID" -ne 0 ]]; then
-#    sudo USER="$USER" --preserve-env "$SOURCE" "$@"
-#    exit
-#fi
-
-php "$DIR/cli/pm.php" "$@"
+php "$DIR/src/pm.php" "$@"

--- a/src/ProcessMaker/CommandLine.php
+++ b/src/ProcessMaker/CommandLine.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ProcessMaker\Cli;
+namespace ProcessMaker;
 
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Helper\ProgressBar;
@@ -19,7 +19,7 @@ class CommandLine
     /**
      * @var float
      */
-    private float $time;
+    private $time;
 
     public function __construct()
     {

--- a/src/ProcessMaker/Composer.php
+++ b/src/ProcessMaker/Composer.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ProcessMaker\Cli;
+namespace ProcessMaker;
 
 use Exception;
 use LogicException;
@@ -12,9 +12,15 @@ use ProcessMaker\Facades\Config;
 
 class Composer
 {
-    public CommandLine $cli;
+    /**
+     * @var \ProcessMaker\CommandLine
+     */
+    public $cli;
 
-    public FileSystem $files;
+    /**
+     * @var \ProcessMaker\FileSystem
+     */
+    public $files;
 
     /**
      * @var
@@ -22,8 +28,8 @@ class Composer
     public $config;
 
     /**
-     * @param  \ProcessMaker\Cli\CommandLine  $cli
-     * @param  \ProcessMaker\Cli\FileSystem  $files
+     * @param  \ProcessMaker\CommandLine  $cli
+     * @param  \ProcessMaker\FileSystem  $files
      */
     public function __construct(CommandLine $cli, FileSystem $files)
     {
@@ -36,7 +42,7 @@ class Composer
      */
     public function getComposerJson(string $path_to_composer_json)
     {
-        if (! $this->files->isDir($path_to_composer_json)) {
+        if (! $this->files->is_dir($path_to_composer_json)) {
             throw new LogicException("Path to composer.json not found: ${path_to_composer_json}");
         }
 

--- a/src/ProcessMaker/Config.php
+++ b/src/ProcessMaker/Config.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ProcessMaker\Cli;
+namespace ProcessMaker;
 
 use ProcessMaker\Facades\Install;
 
@@ -13,7 +13,7 @@ class Config
      *
      * @var array
      */
-    public static array $defaults = [
+    public static $defaults = [
 
         'packages_path' => [
             'description' => 'Absolute path to the directory containing all local copies of enterprise composer packages',

--- a/src/ProcessMaker/Environment.php
+++ b/src/ProcessMaker/Environment.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ProcessMaker\Cli;
+namespace ProcessMaker;
 
 use Generator;
 use RuntimeException;
@@ -25,14 +25,17 @@ class Environment
         'timeout' => '"timeout" executable not found. You may need to install via homebrew using `brew install coreutils`',
     ];
 
-    protected static array $availableChecks = [
+    protected static $availableChecks = [
         'checkExecutables', 'checkPhpExtensions', 'checkNodeVersion', 'checkNpmVersion'
     ];
 
-    protected CommandLine $cli;
+    /**
+     * @var \ProcessMaker\CommandLine
+     */
+    protected $cli;
 
     /**
-     * @param  \ProcessMaker\Cli\CommandLine  $cli
+     * @param  \ProcessMaker\CommandLine  $cli
      */
     public function __construct(CommandLine $cli)
     {
@@ -64,7 +67,7 @@ class Environment
      *
      * @return void
      */
-    public function checkExecutables()
+    public function checkExecutables(): void
     {
         foreach (self::EXECUTABLES as $executable => $message) {
             $this->cli->run("which {$executable}", static function ($errorCode, $output) use ($message) {
@@ -80,7 +83,7 @@ class Environment
      *
      * @throws \RuntimeException
      */
-    public function checkPhpExtensions()
+    public function checkPhpExtensions(): void
     {
         foreach (self::PHP_EXTENSIONS as $extension => $url) {
             if (!extension_loaded($extension)) {
@@ -96,7 +99,7 @@ class Environment
      *
      * @throws \RuntimeException
      */
-    public function checkNodeVersion()
+    public function checkNodeVersion(): void
     {
         $version = $this->cli->runCommand('node -v', static function ($exitCode, $output) {
             throw new RuntimeException($output);
@@ -114,7 +117,7 @@ class Environment
      *
      * @throws \RuntimeException
      */
-    public function checkNpmVersion()
+    public function checkNpmVersion(): void
     {
         $version = $this->cli->runCommand('npm -v', static function ($exitCode, $output) {
             throw new RuntimeException($output);

--- a/src/ProcessMaker/FileSystem.php
+++ b/src/ProcessMaker/FileSystem.php
@@ -2,17 +2,17 @@
 
 declare(strict_types=1);
 
-namespace ProcessMaker\Cli;
+namespace ProcessMaker;
 
-use ProcessMaker\Facades\CommandLine as Cli;
 use RuntimeException;
+use ProcessMaker\Facades\CommandLine as Cli;
 
 class FileSystem
 {
     /**
      * Determine if the given path is a directory.
      */
-    public function isDir(string $path): bool
+    public function is_dir(string $path): bool
     {
         return is_dir($path);
     }
@@ -38,7 +38,7 @@ class FileSystem
      */
     public function rmdir(string $path): bool
     {
-        if (! $this->isDir($path)) {
+        if (! $this->is_dir($path)) {
             return false;
         }
 
@@ -72,7 +72,7 @@ class FileSystem
      */
     public function ensureDirExists(string $path, ?string $owner = null, int $mode = 0755): void
     {
-        if (! $this->isDir($path)) {
+        if (! $this->is_dir($path)) {
             $this->mkdir($path, $owner, $mode);
         }
     }

--- a/src/ProcessMaker/Git.php
+++ b/src/ProcessMaker/Git.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ProcessMaker\Cli;
+namespace ProcessMaker;
 
 use Illuminate\Support\Str;
 use LogicException;
@@ -10,13 +10,19 @@ use RuntimeException;
 
 class Git
 {
-    public CommandLine $cli;
-
-    public FileSystem $files;
+    /**
+     * @var \ProcessMaker\CommandLine
+     */
+    public $cli;
 
     /**
-     * @param  \ProcessMaker\Cli\CommandLine  $cli
-     * @param  \ProcessMaker\Cli\FileSystem  $files
+     * @var \ProcessMaker\FileSystem 
+     */
+    public $files;
+
+    /**
+     * @param  \ProcessMaker\CommandLine  $cli
+     * @param  \ProcessMaker\FileSystem  $files
      */
     public function __construct(CommandLine $cli, FileSystem $files)
     {
@@ -31,7 +37,7 @@ class Git
      */
     public function validateGitRepository(string $path): void
     {
-        if (! $this->files->isDir($path)) {
+        if (! $this->files->is_dir($path)) {
             throw new LogicException("Directory to git repository does not exist: ${path}");
         }
 

--- a/src/ProcessMaker/IDE.php
+++ b/src/ProcessMaker/IDE.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ProcessMaker\Cli;
+namespace ProcessMaker;
 
 use Illuminate\Support\Str;
 
@@ -14,7 +14,7 @@ class IDE
      *
      * @var array<string>
      */
-    public static array $types = [
+    public static $types = [
         'phpstorm' => '.idea',
         'vscode' => '.vscode',
     ];
@@ -22,9 +22,12 @@ class IDE
     /**
      * The temporary directory name
      */
-    public static string $tmp = 'tmp';
+    public static $tmp = 'tmp';
 
-    protected FileSystem $files;
+    /**
+     * @var \ProcessMaker\FileSystem
+     */
+    protected $files;
 
     /**
      * @return void

--- a/src/ProcessMaker/Install.php
+++ b/src/ProcessMaker/Install.php
@@ -2,18 +2,21 @@
 
 declare(strict_types=1);
 
-namespace ProcessMaker\Cli;
+namespace ProcessMaker;
 
 use ProcessMaker\Facades\CommandLine as Cli;
 
 class Install
 {
-    public FileSystem $files;
+    /**
+     * @var \ProcessMaker\FileSystem
+     */
+    public $files;
 
-    public string $bin = HOMEBREW_PREFIX.'/bin/pm';
+    public $bin = HOMEBREW_PREFIX.'/bin/pm';
 
     /**
-     * @param  \ProcessMaker\Cli\FileSystem  $files
+     * @param  \ProcessMaker\FileSystem  $files
      */
     public function __construct(FileSystem $files)
     {
@@ -54,7 +57,7 @@ class Install
         $this->files->chown($this->path(), user());
     }
 
-    public function installed()
+    public function installed(): bool
     {
         return $this->files->exists(PM_HOME_PATH);
     }
@@ -75,6 +78,9 @@ class Install
         $this->files->ensureDirExists(PM_HOME_PATH, user());
     }
 
+    /**
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
     public static function get(string $key)
     {
         return ! blank(($value = resolve(self::class)->read($key))) ? $value : null;
@@ -86,13 +92,10 @@ class Install
      * @param  string|null  $key
      *
      * @return array|string
-     * @throws \JsonException
      */
     public function read(string $key = null)
     {
-        $json = json_decode(
-            $this->files->get($this->path()), true, 512, JSON_THROW_ON_ERROR
-        );
+        $json = json_decode($this->files->get($this->path()), true);
 
         if ($key && is_array($json) && array_key_exists($key, $json)) {
             return $json[$key];

--- a/src/ProcessMaker/PackagesCi.php
+++ b/src/ProcessMaker/PackagesCi.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ProcessMaker\Cli;
+namespace ProcessMaker;
 
 use ProcessMaker\Facades\Config;
 use ProcessMaker\Facades\Git;
@@ -11,6 +11,8 @@ class PackagesCi
 {
     /**
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @throws \Exception
+     * @throws \Exception
      */
     public function install(): void
     {
@@ -31,6 +33,8 @@ class PackagesCi
 
     /**
      * @param  array  $list
+     *
+     * @return string
      */
     private function composerRequireList(array $list): string
     {

--- a/src/ProcessMaker/ProcessManager.php
+++ b/src/ProcessMaker/ProcessManager.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ProcessMaker\Cli;
+namespace ProcessMaker;
 
 use Illuminate\Support\Collection;
 use LogicException;
@@ -15,16 +15,28 @@ class ProcessManager
      */
     public $finalCallback;
 
-    public bool $verbose = false;
-
-    protected Collection $processCollections;
-
-    protected Collection $outputCollection;
-
-    protected CommandLine $cli;
+    /**
+     * @var bool
+     */
+    public $verbose = false;
 
     /**
-     * @param  \ProcessMaker\Cli\CommandLine  $cli
+     * @var \Illuminate\Support\Collection
+     */
+    protected $processCollections;
+
+    /**
+     * @var \Illuminate\Support\Collection
+     */
+    protected $outputCollection;
+
+    /**
+     * @var \ProcessMaker\CommandLine
+     */
+    protected $cli;
+
+    /**
+     * @param  \ProcessMaker\CommandLine  $cli
      * @param  \Illuminate\Support\Collection  $outputCollection
      * @param  \Illuminate\Support\Collection  $processCollections
      */
@@ -50,7 +62,6 @@ class ProcessManager
 
     /**
      * @param  callable  $callback
-     * @param  array  $arguments
      *
      * @return void
      */
@@ -149,14 +160,18 @@ class ProcessManager
      */
     public function buildProcessesBundle(array $commands): Collection
     {
-        $commands = array_filter($commands, static fn ($command) => ! is_string($command));
+        $commands = array_filter($commands, static function ($command) {
+            return ! is_string($command);
+        });
 
         if (blank($commands)) {
             throw new LogicException('Commands array cannot be empty');
         }
 
         $bundles = collect($commands)->transform(function (array $set) {
-            return collect(array_map(static fn ($command) => new Process($command), $set));
+            return collect(array_map(static function ($command) {
+                return new Process($command);
+            }, $set));
         });
 
         return $this->setExitListeners($bundles);
@@ -281,7 +296,9 @@ class ProcessManager
      */
     private function validateBundle(Collection $bundle): Collection
     {
-        return $bundle->reject(fn ($process) => ! $process instanceof Process);
+        return $bundle->reject(function ($process) {
+            return ! $process instanceof Process;
+        });
     }
 
     /**
@@ -292,7 +309,9 @@ class ProcessManager
     private function getStartProcesses(Collection $bundles): Collection
     {
         return $this->validateBundle(
-            $bundles->map(fn (Collection $bundle) => $bundle->first())
+            $bundles->map(function (Collection $bundle) {
+                return $bundle->first();
+            })
         );
     }
 
@@ -304,6 +323,7 @@ class ProcessManager
     private function setProcessIndexes(Collection $bundles): void
     {
         $index = 0;
+
         $total_processes = 0;
 
         // Count up all of the processes

--- a/src/ProcessMaker/Reset.php
+++ b/src/ProcessMaker/Reset.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ProcessMaker\Cli;
+namespace ProcessMaker;
 
 use DomainException;
 use Illuminate\Support\Str;
@@ -18,33 +18,54 @@ use function array_merge;
 
 class Reset
 {
-    protected CommandLine $cli;
+    /**
+     * @var \ProcessMaker\CommandLine
+     */
+    protected $cli;
 
-    protected FileSystem $files;
+    /**
+     * @var \ProcessMaker\FileSystem
+     */
+    protected $files;
 
-    protected string $branch = '';
+    /**
+     * @var string
+     */
+    protected $branch = '';
 
-    protected static array $artisanInstallCommands = [
+    /**
+     * @var array
+     */
+    protected static $artisanInstallCommands = [
         PHP_BINARY.' artisan passport:install --no-interaction',
         PHP_BINARY.' artisan storage:link --no-interaction'
     ];
 
-    protected static array $gitCommands = [
+    /**
+     * @var array
+     */
+    protected static $gitCommands = [
         'git checkout {branch}',
     ];
 
-    protected static array $composerCommands = [
+    /**
+     * @var array
+     */
+    protected static $composerCommands = [
         'composer install --optimize-autoloader --no-interaction --no-progress',
     ];
 
-    protected static array $npmCommands = [
+    /**
+     * @var array
+     */
+    protected static $npmCommands = [
         'npm install --non-interactive --quiet',
         'npm run dev --non-interactive --quiet',
     ];
 
     /**
-     * @param  \ProcessMaker\Cli\CommandLine  $cli
-     * @param  \ProcessMaker\Cli\FileSystem  $files
+     * @param  \ProcessMaker\CommandLine  $cli
+     * @param  \ProcessMaker\FileSystem  $files
      */
     public function __construct(CommandLine $cli, FileSystem $files)
     {

--- a/src/ProcessMaker/Supervisor.php
+++ b/src/ProcessMaker/Supervisor.php
@@ -2,17 +2,20 @@
 
 declare(strict_types=1);
 
-namespace ProcessMaker\Cli;
+namespace ProcessMaker;
 
 use RuntimeException;
 use Illuminate\Support\Str;
 
 class Supervisor
 {
-    protected CommandLine $cli;
+    /**
+     * @var \ProcessMaker\CommandLine
+     */
+    protected $cli;
 
     /**
-     * @param  \ProcessMaker\Cli\CommandLine  $cli
+     * @param  \ProcessMaker\CommandLine  $cli
      */
     public function __construct(CommandLine $cli)
     {

--- a/src/pm.php
+++ b/src/pm.php
@@ -11,10 +11,12 @@ if (file_exists(__DIR__.'/../vendor/autoload.php')) {
     require getenv('HOME').'/.composer/vendor/autoload.php';
 }
 
+use ProcessMaker\CommandLine;
 use Illuminate\Container\Container;
 use Illuminate\Support\Str;
 use ProcessMaker\Facades\Config;
 use ProcessMaker\Facades\PackagesCi;
+use ProcessMaker\ProcessManager;
 use ProcessMaker\Facades\Environment;
 use ProcessMaker\Facades\FileSystem;
 use ProcessMaker\Facades\Git;
@@ -29,13 +31,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\Question;
 
-use function ProcessMaker\Cli\codebase_path;
-use function ProcessMaker\Cli\info;
-use function ProcessMaker\Cli\output;
-use function ProcessMaker\Cli\resolve;
-use function ProcessMaker\Cli\table;
-use function ProcessMaker\Cli\warning;
-use function ProcessMaker\Cli\warningThenExit;
+use function ProcessMaker\codebase_path;
+use function ProcessMaker\info;
+use function ProcessMaker\output;
+use function ProcessMaker\resolve;
+use function ProcessMaker\table;
+use function ProcessMaker\warning;
+use function ProcessMaker\warningThenExit;
 
 Container::setInstance(new Container());
 
@@ -73,7 +75,7 @@ $app->command('ci:install-packages', function (): void {
     PackagesCi::install();
 })->descriptions('Intended to use with CircleCi to install necessary enterprise packages for testing');
 
-if (! FileSystem::isDir(PM_HOME_PATH)) {
+if (!is_dir(PM_HOME_PATH)) {
     /*
      * -------------------------------------------------+
      * |                                                |
@@ -122,7 +124,7 @@ if (! FileSystem::isDir(PM_HOME_PATH)) {
 		$current = 0;
 
 		// Iterate through the defaults to build the config.json contents
-		foreach ($configuration = \ProcessMaker\Cli\Config::$defaults as $config_key => $config) {
+		foreach ($configuration = \ProcessMaker\Config::$defaults as $config_key => $config) {
 
 			// Keep track of where were at for the user's sake
             $current += 1;
@@ -341,7 +343,7 @@ if (! FileSystem::isDir(PM_HOME_PATH)) {
             }
 
             // Grab an instance of the CommandLine class
-            $cli = resolve(\ProcessMaker\Cli\CommandLine::class);
+            $cli = resolve(CommandLine::class);
 
 			// Since we completely remove the codebase directory when resetting,
 	        // we need to make sure the current working directory is different
@@ -542,7 +544,7 @@ if (! FileSystem::isDir(PM_HOME_PATH)) {
             }
 
             // Grab an instance of the CommandLine class
-            $cli = resolve(\ProcessMaker\Cli\CommandLine::class);
+            $cli = resolve(CommandLine::class);
 
             // Count up the total number of steps
             $steps = $install_commands->flatten()->count();
@@ -664,7 +666,7 @@ if (! FileSystem::isDir(PM_HOME_PATH)) {
         $verbose = $input->getOption('verbose');
 
 		// Grab an instance of the Packages class
-		$packages = resolve(\ProcessMaker\Cli\Packages::class);
+		$packages = resolve(\ProcessMaker\Packages::class);
 
         // Build the commands for each package (keyed by package name)
         $commands = $packages->buildPullCommands($for_41_develop ? '4.1-develop' : 'develop');
@@ -673,7 +675,7 @@ if (! FileSystem::isDir(PM_HOME_PATH)) {
 		$metadata = $packages->takePackagesSnapshot();
 
 		// Grab an instance ProcessManager
-        $processManager = resolve(\ProcessMaker\Cli\ProcessManager::class);
+        $processManager = resolve(ProcessManager::class);
 
 		// Set verbosity
 		$processManager->setVerbosity($verbose);

--- a/tests/PackagesCiTest.php
+++ b/tests/PackagesCiTest.php
@@ -1,9 +1,9 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
-use ProcessMaker\Cli\CommandLine;
-use \PackagesCi;
-use function ProcessMaker\Cli\swap;
+use ProcessMaker\CommandLine;
+
+use function ProcessMaker\swap;
 
 class PackagesCiTest extends TestCase
 {
@@ -23,7 +23,7 @@ class PackagesCiTest extends TestCase
     /**
      * @return void
      */
-    public function testCiInstall()
+    public function testCiInstall(): void
     {
         $cli = Mockery::mock(CommandLine::class);
         $any = Mockery::any();


### PR DESCRIPTION
- Now compatible with PHP down to version 7.2
- Refactored Facades to use a singleton method of making/retrieving instances out of the container
- Refactored includes so only includes/scope.php is autoloaded by composer. This is to prevent namespace collisions if both this package and [laravel/valet](https://github.com/laravel/valet) are globally required packages by composer.